### PR TITLE
Update TODO list for ZarrArray integration

### DIFF
--- a/TODO
+++ b/TODO
@@ -39,14 +39,6 @@ o Benchmarking:
 After ZarrArray is accepted and added to BioC 3.23
 ==================================================
 
-o Only packages that seem to be using Rarr::ZarrArray() at the moment are
-  - ImageArray from Artür:
-      https://github.com/Bioconductor/Contributions/issues/3946)
-  - SpatialData from Helena L. Crowell (not submitted to Bioconductor yet):
-      https://github.com/HelenaLC/SpatialData
-  Make them use ZarrArray::ZarrArray() instead, after replacing Rarr with
-  ZarrArray in Imports.
-
 o Register realization backend _ZarrArray in the DelayedArray package.
 
 o Implement saveZarrSummarizedExperiment() and


### PR DESCRIPTION
Both `ImageArray` and `SpatialData` now depend on BioC/ZarrArray.