### PR TITLE
Use new simpler Rarr:::.read_array_metadata() interface

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Authors@R: c(
 		comment=c(ORCID="0000-0003-2725-0694")))
 Depends: R (>= 3.4), methods, SparseArray, DelayedArray
 Imports: stats, tools, BiocGenerics, S4Vectors, IRanges, S4Arrays,
-	Rarr (>= 1.11.33)
+	Rarr (>= 2.1.9)
 Suggests: paws.storage, HDF5Array, testthat, knitr, rmarkdown, BiocStyle
 VignetteBuilder: knitr
 Collate:

--- a/R/ZarrArraySeed-class.R
+++ b/R/ZarrArraySeed-class.R
@@ -49,12 +49,7 @@ setMethod("chunkdim", "ZarrArraySeed", function(x) x@chunkdim)
 setMethod("extract_array", "ZarrArraySeed",
     function(x, index)
     {
-        ans <- Rarr::read_zarr_array(x@zarr_path, index, x@s3_client)
-        ## Temporary fix.
-        ## See https://github.com/Huber-group-EMBL/Rarr/issues/137
-        if (typeof(ans) != x@type)
-            storage.mode(ans) <- x@type
-        ans
+        Rarr::read_zarr_array(x@zarr_path, index, x@s3_client)
     }
 )
 

--- a/R/ZarrArraySeed-class.R
+++ b/R/ZarrArraySeed-class.R
@@ -90,20 +90,17 @@ setMethod("show", "ZarrArraySeed",
 .extract_chunkdim_from_metadata <- function(metadata)
 {
     stopifnot(is.list(metadata), !is.null(names(metadata)))
-    chunkdim <- metadata$chunks  # only in Zarr v2
-    if (is.null(chunkdim)) {
-        chunk_grid <- metadata$chunk_grid  # only in Zarr v3
-        if (is.null(chunk_grid))
-            stop(wmsg("unable to determine the chunk dimensions ",
-                      "for this Zarr dataset"))
-        if (!identical(chunk_grid$name, "regular"))
-            stop(wmsg("only Zarr datasets with a regular chunk ",
-                      "grid are supported at the moment"))
-        chunkdim <- chunk_grid$configuration$chunk_shape
-        if (is.null(chunkdim))
-            stop(wmsg("unable to determine the chunk dimensions ",
-                      "for this Zarr dataset"))
-    }
+    chunk_grid <- metadata$chunk_grid  # only in Zarr v3
+    if (is.null(chunk_grid))
+        stop(wmsg("unable to determine the chunk dimensions ",
+                    "for this Zarr dataset"))
+    if (!identical(chunk_grid$name, "regular"))
+        stop(wmsg("only Zarr datasets with a regular chunk ",
+                    "grid are supported at the moment"))
+    chunkdim <- chunk_grid$configuration$chunk_shape
+    if (is.null(chunkdim))
+        stop(wmsg("unable to determine the chunk dimensions ",
+                    "for this Zarr dataset"))
     if (is.list(chunkdim))
         chunkdim <- unlist(chunkdim, use.names=FALSE)
     if (!is.numeric(chunkdim))

--- a/R/utils.R
+++ b/R/utils.R
@@ -72,11 +72,7 @@ compute_max_string_size <- function(x, keepNA=FALSE)
 
 .normarg_fill_value <- function(fill_value, type, nchar=NULL)
 {
-    if (is.null(fill_value)) {
-        dt <- Rarr:::.check_datatype(type, nchar=nchar)
-    } else {
-        dt <- Rarr:::.check_datatype(type, fill_value, nchar=nchar)
-    }
+    dt <- Rarr:::.check_datatype(type, fill_value, nchar=nchar)
     stopifnot(identical(names(dt), c("data_type", "fill_value")))
     dt$fill_value
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -43,7 +43,7 @@ zarrtype2Rtype <- function(base_type)
                       float="double",
                       #complex="complex",
                       string=, unicode="character",
-                      stop(wmsg("unreocgnized Zarr base type: ", base_type)))
+                      stop(wmsg("unrecognized Zarr base type: ", base_type)))
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -17,50 +17,17 @@ trim_trailing_slashes <- function(x)
 ### get_zarr_metadata()
 ###
 
-.ZARR_V2_METADATA_FILE <- ".zarray"
-.ZARR_V3_METADATA_FILE <- "zarr.json"
-
-.get_zarr_metadata_file <- function(zarr_path, s3_client=NULL)
-{
-    stopifnot(S4Vectors:::has_suffix(zarr_path, "/"))
-    metadata_files <- c(.ZARR_V2_METADATA_FILE, .ZARR_V3_METADATA_FILE)
-    ok <- Rarr:::.file_or_blob_exists(zarr_path, s3_client, metadata_files)
-    if (!any(ok))
-        stop(wmsg("No Zarr metadata file ('", .ZARR_V2_METADATA_FILE, "' ",
-                  "or '", .ZARR_V3_METADATA_FILE, "') found in: ", zarr_path),
-             "\n  ",
-             wmsg("Are you sure this is the path to a Zarr dataset?"))
-    if (all(ok))
-        stop(wmsg("Invalid Zarr dataset at: ", zarr_path),
-             "\n  ",
-             wmsg("Directory contains Zarr metadata files ",
-                   "'", .ZARR_V2_METADATA_FILE, "' and ",
-                   "'", .ZARR_V3_METADATA_FILE, "'. Should contain one ",
-                   "or the other, but not both."))
-    names(ok)[ok]
-}
-
 ### Only used in the unit tests at the moment.
 get_zarr_format <- function(zarr_path, s3_client=NULL)
 {
-    stopifnot(isSingleString(zarr_path))
-    metadata_file <- .get_zarr_metadata_file(zarr_path, s3_client=s3_client)
-    if (metadata_file == .ZARR_V3_METADATA_FILE) 3L else 2L
+    get_zarr_metadata(zarr_path, s3_client=s3_client)$zarr_format
 }
 
 ### Returns the metadata in a named list.
-### IMPORTANT NOTE: The exact components of the named list and their names
-### depend on the Zarr version (a.k.a. Zarr format) of the Zarr dataset,
-### which can be 2 or 3. However, the Rarr package has
-### Rarr:::.convert_metadata_version() for converting the metadata
-### to a given version. This is something that we could use in
-### get_zarr_metadata() to always return the metadata in the same
-### form e.g. in the form that corresponds to Zarr v3.
 get_zarr_metadata <- function(zarr_path, s3_client=NULL)
 {
     stopifnot(isSingleString(zarr_path))
-    metadata_file <- .get_zarr_metadata_file(zarr_path, s3_client=s3_client)
-    Rarr:::.read_array_metadata(zarr_path, metadata_file, s3_client=s3_client)
+    Rarr:::.read_array_metadata(zarr_path, s3_client=s3_client)
 }
 
 


### PR DESCRIPTION
- [`d349d51` (this PR)](https://github.com/Bioconductor/ZarrArray/pull/7/commits/d349d51cbf3b229bfe574c418e0c334daf03dc06) fixes the R CMD check error
- the other commits are quality of life improvements based on recent changes in Rarr

Note to myself: revert https://github.com/Huber-group-EMBL/Rarr/pull/190 when this (or any other change solving this issue) gets merged.